### PR TITLE
Fixed collisions on top bug

### DIFF
--- a/src/Actors/Player/States/Dash.cs
+++ b/src/Actors/Player/States/Dash.cs
@@ -100,6 +100,7 @@ public class Dash : Move
                 else
             {
                 animationPlayer.Play("Dash");
+                base.isDashing = true;
             }
 
             if (GameManager.AudioOn)
@@ -189,5 +190,6 @@ public class Dash : Move
             this.playerCollisionShape.Disabled = false;
         }
         player.PlayerTrail.Emitting = true;
+        base.isDashing = false;
     }
 }

--- a/src/Actors/Player/States/Move.cs
+++ b/src/Actors/Player/States/Move.cs
@@ -24,12 +24,14 @@ abstract public class Move : State
     public Vector2 SnapVector = new Vector2(0f, 32f);
 
     public Boolean hasDashed;
+    public Boolean isDashing;
 
     public override void _Ready()
     {
         base._Ready();
         this.Acceleration = this.AccelerationDefault;
         this.MaxSpeed = this.MaxSpeedDefault;
+        this.isDashing = false;
     }
 
     public override void UnhandledInput(InputEvent @event)
@@ -95,7 +97,7 @@ abstract public class Move : State
 
         var collisionInfo = player.MoveAndCollide(this.Velocity * delta, true, true, true);
 
-        if (collisionInfo != null)
+        if (collisionInfo != null && !isDashing)
         {
             foreach (Node2D node in GetTree().GetNodesInGroup("killingObstacles"))
             {


### PR DESCRIPTION
When the player was dashing and collided with a dashable object on the top, it was being killed. Not anymore