### PR TITLE
:bug: Collisions on dash work on range

### DIFF
--- a/src/Actors/Player/States/Dash.cs
+++ b/src/Actors/Player/States/Dash.cs
@@ -19,7 +19,9 @@ public class Dash : Move
     CollisionShape2D slideCollisionShape;
     Boolean collisionDetected;
     private float playerWidth = 100;
+    private float playerPositionOnYMin = 797;
     private float playerPositionOnY = 861.6033f;
+    private float playerPositionOnYMax = 862;
 
 
     // Called when the node enters the scene tree for the first time.
@@ -136,7 +138,7 @@ public class Dash : Move
         {
             if (node.GlobalPosition.x > player.Position.x && node.GlobalPosition.x < player.Position.x + ((float)msg["impulse"] / 2))
             {
-                if (player.Position.y >= this.playerPositionOnY)
+                if (player.Position.y >= this.playerPositionOnYMin && player.Position.y <= playerPositionOnYMax)
                 {
                     dashTween.InterpolateProperty
                     (


### PR DESCRIPTION
Improved the way of handling the collisions for the dash, now works in a range instead of just one position