### PR TITLE
Fix collision bug

### DIFF
--- a/src/Actors/Player/Player.cs
+++ b/src/Actors/Player/Player.cs
@@ -52,15 +52,29 @@ public class Player : Actor
 		this.playerNameLabel.Visible = true;
 	}
 
-	public void _on_AnimationPlayer_animation_finished(String anim_name)
-	{
-		GD.Print("Player::_on_AnimationPlayer_animation_finished() anim_name is " + anim_name);
+	// public void _on_AnimationPlayer_animation_finished(String anim_name)
+	// {
+	// 	GD.Print("Player::_on_AnimationPlayer_animation_finished() anim_name is " + anim_name);
 
+	// 	if (0 == this.gameManager.GracePeriod)
+	// 	{
+	// 		EmitSignal(nameof(PlayerDied), "expired");
+	// 	}
+	// 	else if ("Fall" == anim_name)
+	// 	{
+	// 		EmitSignal(nameof(PlayerDied), "collision");
+	// 		this.playerNameLabel.Visible = true;
+	// 	}
+	// }
+
+	public void _on_DieTimer_timeout()
+	{
+		GD.Print("Player::_on_DieTimer_timeout()");
 		if (0 == this.gameManager.GracePeriod)
 		{
 			EmitSignal(nameof(PlayerDied), "expired");
 		}
-		else if ("Fall" == anim_name)
+		else
 		{
 			EmitSignal(nameof(PlayerDied), "collision");
 			this.playerNameLabel.Visible = true;
@@ -113,4 +127,6 @@ public class Player : Actor
 	{
 		this.playerNameLabel.Visible = false;
 	}
+
+	
 }

--- a/src/Actors/Player/Player.tscn
+++ b/src/Actors/Player/Player.tscn
@@ -177,7 +177,7 @@ script = ExtResource( 36 )
 
 [node name="Sprite" type="Sprite" parent="BodyPivot"]
 scale = Vector2( 0.5, 0.5 )
-texture = ExtResource( 27 )
+texture = ExtResource( 34 )
 
 [node name="PlayerNameLabel" type="Label" parent="BodyPivot"]
 margin_top = -100.0
@@ -224,6 +224,9 @@ script = ExtResource( 7 )
 
 [node name="AudioStreamPlayer" type="AudioStreamPlayer" parent="StateMachine/Die"]
 stream = ExtResource( 38 )
+
+[node name="DieTimer" type="Timer" parent="StateMachine/Die"]
+one_shot = true
 
 [node name="Idle" type="Node" parent="StateMachine"]
 script = ExtResource( 3 )
@@ -294,6 +297,8 @@ texture_scale = 3.0
 shadow_enabled = true
 [connection signal="timeout" from="BodyPivot/PlayerNameTimer" to="." method="_on_PlayerNameTimer_timeout"]
 [connection signal="DieSignal" from="StateMachine/Die" to="CameraPivot/CameraOffset/Camera2D/ScreenShake" method="_on_Die_DieSignal"]
+[connection signal="timeout" from="StateMachine/Die/DieTimer" to="." method="_on_DieTimer_timeout"]
+[connection signal="timeout" from="StateMachine/Die/DieTimer" to="StateMachine/Die" method="_on_DieTimer_timeout"]
 [connection signal="DashSignal" from="StateMachine/Dash" to="CameraPivot/CameraOffset/Camera2D/ScreenShake" method="_on_Dash_DashSignal"]
 [connection signal="timeout" from="StateMachine/Dash/DashTimer" to="StateMachine/Dash" method="_OnDashTimerTimeout"]
 [connection signal="timeout" from="StateMachine/Dash/GhostTimer" to="StateMachine/Dash" method="_OnGhostTimerTimeout"]

--- a/src/Actors/Player/Player.tscn
+++ b/src/Actors/Player/Player.tscn
@@ -66,7 +66,7 @@ tracks/0/enabled = true
 tracks/0/keys = {
 "times": PoolRealArray( 0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1, 1.1, 1.2, 1.3, 1.4 ),
 "transitions": PoolRealArray( 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ),
-"update": 1,
+"update": 0,
 "values": [ ExtResource( 27 ), ExtResource( 26 ), ExtResource( 35 ), ExtResource( 28 ), ExtResource( 30 ), ExtResource( 23 ), ExtResource( 25 ), ExtResource( 24 ), ExtResource( 22 ), ExtResource( 32 ), ExtResource( 29 ), ExtResource( 31 ), ExtResource( 21 ), ExtResource( 33 ), ExtResource( 34 ) ]
 }
 
@@ -177,7 +177,7 @@ script = ExtResource( 36 )
 
 [node name="Sprite" type="Sprite" parent="BodyPivot"]
 scale = Vector2( 0.5, 0.5 )
-texture = ExtResource( 19 )
+texture = ExtResource( 27 )
 
 [node name="PlayerNameLabel" type="Label" parent="BodyPivot"]
 margin_top = -100.0

--- a/src/Actors/Player/Player.tscn
+++ b/src/Actors/Player/Player.tscn
@@ -177,7 +177,7 @@ script = ExtResource( 36 )
 
 [node name="Sprite" type="Sprite" parent="BodyPivot"]
 scale = Vector2( 0.5, 0.5 )
-texture = ExtResource( 34 )
+texture = ExtResource( 27 )
 
 [node name="PlayerNameLabel" type="Label" parent="BodyPivot"]
 margin_top = -100.0
@@ -302,5 +302,3 @@ shadow_enabled = true
 [connection signal="DashSignal" from="StateMachine/Dash" to="CameraPivot/CameraOffset/Camera2D/ScreenShake" method="_on_Dash_DashSignal"]
 [connection signal="timeout" from="StateMachine/Dash/DashTimer" to="StateMachine/Dash" method="_OnDashTimerTimeout"]
 [connection signal="timeout" from="StateMachine/Dash/GhostTimer" to="StateMachine/Dash" method="_OnGhostTimerTimeout"]
-[connection signal="animation_finished" from="AnimationPlayer" to="." method="_on_AnimationPlayer_animation_finished"]
-[connection signal="animation_finished" from="AnimationPlayer" to="StateMachine/Die" method="_on_AnimationPlayer_animation_finished"]

--- a/src/Actors/Player/States/Dash.cs
+++ b/src/Actors/Player/States/Dash.cs
@@ -175,10 +175,6 @@ public class Dash : Move
     {
 //        GD.Print("Dash::Exit()");
         this.Acceleration = this.AccelerationDefault;
-        // In "Slide" in Enter() we turn off the player collision and turn on the slide. Put things back.
-        this.playerCollisionShape.Disabled = false;
-        this.slideCollisionShape.Disabled = true;
-
         base.Exit();
     }
 

--- a/src/Actors/Player/States/Dash.cs
+++ b/src/Actors/Player/States/Dash.cs
@@ -175,6 +175,10 @@ public class Dash : Move
     {
 //        GD.Print("Dash::Exit()");
         this.Acceleration = this.AccelerationDefault;
+        // In "Slide" in Enter() we turn off the player collision and turn on the slide. Put things back.
+        this.playerCollisionShape.Disabled = false;
+        this.slideCollisionShape.Disabled = true;
+
         base.Exit();
     }
 

--- a/src/Actors/Player/States/Die.cs
+++ b/src/Actors/Player/States/Die.cs
@@ -7,10 +7,13 @@ public class Die : Move
 
     [Signal]
     public delegate void DieSignal();
+    private Timer dieTimer;
 
     public override void Enter(Dictionary<string, object> msg = null)
     {
         base.Enter(msg);
+
+        this.dieTimer = this.GetNode<Timer>("DieTimer");
 
         if (GameManager.AudioOn)
         {
@@ -20,6 +23,7 @@ public class Die : Move
         
         this.player.IsDead = true;
         player.AnimationPlayer.Play("Fall");
+        dieTimer.Start(1.5f);
         player.PlayerTrail.Emitting = false;
 
         EmitSignal(nameof(DieSignal));
@@ -30,15 +34,21 @@ public class Die : Move
 
     public override void Exit()
     {
-//        GD.Print("Die::Exit()");
+        GD.Print("Die::Exit()");
         moveDirection = Vector2.Zero;
         Velocity = Vector2.Zero;
         base.Exit();
     }
 
-    public void _on_AnimationPlayer_animation_finished(String anim_name)
+    // public void _on_AnimationPlayer_animation_finished(String anim_name)
+    // {
+    //     GD.Print("Die::_on_AnimationPlayer_animation_finished() anim_name is " + anim_name);
+    //     this.Exit();
+    // }
+
+    public void _on_DieTimer_timeout()
     {
-        GD.Print("Die::_on_AnimationPlayer_animation_finished() anim_name is " + anim_name);
+        GD.Print("Die::_on_DieTimer_timeout()");
         this.Exit();
     }
 }

--- a/src/Scenes/Block.tscn
+++ b/src/Scenes/Block.tscn
@@ -7,7 +7,7 @@
 extents = Vector2( 10, 9.28096 )
 
 [sub_resource type="RectangleShape2D" id=2]
-extents = Vector2( 121.188, 10 )
+extents = Vector2( 118.55, 10 )
 
 [node name="Block" type="Node2D"]
 scale = Vector2( 0.5, 0.5 )
@@ -37,5 +37,5 @@ shape = SubResource( 1 )
 collision_layer = 2
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="StaticBody2D2"]
-position = Vector2( 0, -279.165 )
+position = Vector2( 1.85432, -278.798 )
 shape = SubResource( 2 )

--- a/src/Scenes/Block.tscn
+++ b/src/Scenes/Block.tscn
@@ -7,7 +7,7 @@
 extents = Vector2( 10, 9.28096 )
 
 [sub_resource type="RectangleShape2D" id=2]
-extents = Vector2( 118.55, 10 )
+extents = Vector2( 120.052, 10 )
 
 [node name="Block" type="Node2D"]
 scale = Vector2( 0.5, 0.5 )
@@ -37,5 +37,5 @@ shape = SubResource( 1 )
 collision_layer = 2
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="StaticBody2D2"]
-position = Vector2( 1.85432, -278.798 )
+position = Vector2( -0.153721, -278.56 )
 shape = SubResource( 2 )


### PR DESCRIPTION
Sometimes when dashing and falling just before an obstacle, the death animation doesn't play and the game was waiting for it to be ended.
In this commit, we now wait in seconds for the animation to end and when it doesn't play, the game finishes itself too.

This is a hack that needs to be solved later with the animation actually playing